### PR TITLE
use relative file paths in platformio.ini

### DIFF
--- a/week01/lab01-maxbotix-demo/platformio.ini
+++ b/week01/lab01-maxbotix-demo/platformio.ini
@@ -21,4 +21,4 @@ lib_deps =
 
 lib_extra_dirs = 
 	; you'll need to change this to where you put the library
-	/Users/greg/Documents/PlatformIO/lib/rbe-200n-lib
+	../../rbe-200n-lib

--- a/week01/lab01-standoff/platformio.ini
+++ b/week01/lab01-standoff/platformio.ini
@@ -22,4 +22,4 @@ lib_deps =
 
 lib_extra_dirs =
     ; set to your local directory where you saved the library
-    /Users/greg/Documents/PlatformIO/lib/rbe-200n-lib
+    ../../rbe-200n-lib

--- a/week02/platformio.ini
+++ b/week02/platformio.ini
@@ -22,4 +22,4 @@ lib_deps =
 
 lib_extra_dirs =
     ; set to your local directory where you saved the libraries
-    /Users/greg/Documents/PlatformIO/skeleton codes/rbe2002/rbe-200n-lib
+    ../rbe-200n-lib


### PR DESCRIPTION
the use of absolute file paths to refer to rbe-200n-lib creates user confusion as well as potentially creating a dependency on code outside of the repository, exacerbating "works on my machine" syndrome.